### PR TITLE
Refactor patch processing

### DIFF
--- a/docker/cmd.sh
+++ b/docker/cmd.sh
@@ -60,9 +60,9 @@ case "$subcommand" in
     pushd /opt/eve-echoes-tools
     if [ -z "$patch_path" ]
     then 
-        python3 scripts/dump_static_data.py $xapk_path $out_dir
+        python3 scripts/dump_static_data.py --xapk $xapk_path $out_dir
     else
-        python3 scripts/dump_static_data.py --patch $patch_path $xapk_path $out_dir
+        python3 scripts/dump_static_data.py -p $patch_path --xapk $xapk_path $out_dir
     fi
     popd
 

--- a/scripts/dump_static_data.py
+++ b/scripts/dump_static_data.py
@@ -288,7 +288,7 @@ def dump_script(filename, relative_dir, root_dir):
                 c_pyc_file.name, pyc_script_file.name]) != 0:
         from shutil import copyfile
         filedir = os.path.join(
-            args.outdir, "failed", os.path.dirname(filename))
+            args.outdir, "failed", relative_dir, os.path.dirname(filename))
         try:
             lock.acquire()
             if not os.path.exists(filedir):
@@ -296,7 +296,7 @@ def dump_script(filename, relative_dir, root_dir):
         finally:
             lock.release()
         copyfile(c_pyc_file.name, os.path.join(
-            args.outdir, "failed", filename))
+            args.outdir, "failed", relative_dir, filename))
 
     os.remove(c_pyc_file.name)
 
@@ -305,7 +305,7 @@ def dump_script(filename, relative_dir, root_dir):
                     "-o", py_file.name, pyc_script_file.name]) != 0:
             from shutil import copyfile
             filedir = os.path.join(
-                args.outdir, "failed", os.path.dirname(filename))
+                args.outdir, "failed", relative_dir, os.path.dirname(filename))
             try:
                 lock.acquire()
                 if not os.path.exists(filedir):
@@ -313,7 +313,7 @@ def dump_script(filename, relative_dir, root_dir):
             finally:
                 lock.release()
             copyfile(pyc_script_file.name, os.path.join(
-                args.outdir, "failed", filename + ".pyc"))
+                args.outdir, "failed", relative_dir, filename + ".pyc"))
         os.remove(pyc_script_file.name)
 
         py_file.close()
@@ -557,11 +557,11 @@ if __name__ == '__main__':
                 if args.patch is not None:
                     process_patch_file_listing(args.patch)
 
-                # Extract all NPK files to game_data folder
+                ## Extract all NPK files to game_data folder
                 print('Extracting game assets')
                 dump_from_unpacked_data(unpack_dir, game_data_dir)
 # 
-                # Copy OBB res/* to game_data folder
+                ## Copy OBB res/* to game_data folder
                 print('Moving static data into game data...')
                 static_data_src = os.path.join(unpack_dir, 'assets', 'res', 'staticdata')
                 static_data_dest = os.path.join(game_data_dir, 'staticdata')

--- a/scripts/dump_static_data.py
+++ b/scripts/dump_static_data.py
@@ -163,12 +163,11 @@ def process_patch_file_listing(patch_file_dir):
     m = collections.OrderedDict()
     lines = filelist.splitlines()
     numLines = len(lines)
-    print("Parsing", numLines, "patch files...", end='')
+    print("Parsing", numLines, "patch files...", end='\r')
     i = 0
     for line in lines:
         i += 1
-        print('\r', end='') 
-        print('Parsing patch entry:', i, "/", numLines, end='')
+        print('Parsing patch entry:', i, "/", numLines, end='\r')
         info = line.split('\t')
         patch_file = str(info[1])
         filename = str(info[5])
@@ -176,13 +175,18 @@ def process_patch_file_listing(patch_file_dir):
 
     global patch_file_map
     patch_file_map = m
-    print() # To run next print on a new line
 
 
 def apply_patch_files(patch_file_dir, game_data_dir):
     for root, _, filenames in os.walk(patch_file_dir):
+        i = 0
+        numFiles = len(filenames)
         for filename in filenames:
-            if filename in patch_file_map:
+            i += 1
+            if filename.startswith('.') or filename in ['filelist.txt', PATCH_FILE_INDEX]:
+                pass
+            elif filename in patch_file_map:
+                print('Applying patch file', i, "/", numFiles, filename, end='\r')
                 patch_file_path_src = os.path.join(root, filename)
                 patch_file_path_dest = os.path.join(game_data_dir, patch_file_map[filename])
                 patch_file_path_dest_dir = os.path.dirname(patch_file_path_dest)
@@ -193,6 +197,7 @@ def apply_patch_files(patch_file_dir, game_data_dir):
                 shutil.copyfile(patch_file_path_src, patch_file_path_dest)
             else:
                 warn('Patch file not found in index! {}'.format(filename))
+    print('\033[KPatch files applied.')
 
 # TODO(alexander): Move this to neox-tools
 # In some way at least, maybe strip it down a bit idk
@@ -552,11 +557,11 @@ if __name__ == '__main__':
                 if args.patch is not None:
                     process_patch_file_listing(args.patch)
 
-                ## Extract all NPK files to game_data folder
+                # Extract all NPK files to game_data folder
                 print('Extracting game assets')
                 dump_from_unpacked_data(unpack_dir, game_data_dir)
-
-                ## Copy OBB res/* to game_data folder
+# 
+                # Copy OBB res/* to game_data folder
                 print('Moving static data into game data...')
                 static_data_src = os.path.join(unpack_dir, 'assets', 'res', 'staticdata')
                 static_data_dest = os.path.join(game_data_dir, 'staticdata')

--- a/scripts/dump_static_data.py
+++ b/scripts/dump_static_data.py
@@ -120,9 +120,19 @@ def process_patch_files(patch_file_dir):
     if type(filelist) is not str:
         filelist = filelist.decode('utf-8')
 
-    print("Parsing patch files for existence...")
+    f = open(os.path.join(patch_file_dir, "filelist.txt"), "w")
+    f.write(filelist)
+    f.close()
+
     m = collections.OrderedDict()
-    for line in filelist.splitlines():
+    lines = filelist.splitlines()
+    numLines = len(lines)
+    print("Parsing", numLines, "patch files for existence...")
+    i = 0
+    for line in lines:
+        i += 1
+        print(i, "/", numLines, end="", flush=True)
+        print('\r', end='') 
         info = line.split('\t')
         patch_file = check_patch_file_exists(info[1])
         filename = str(info[5])
@@ -513,7 +523,7 @@ if __name__ == '__main__':
         process_patch_files(args.patch)
 
     if args.obb is not None and args.apk is not None:
-        print('Reading data files from {} {}', args.obb, args.apk)
+        print('Reading data files from ', args.obb, args.apk)
         dump_scripts_from_apk_data(args.apk)
         dump_static_data_fsd_from_obb_data(args.obb)
 


### PR DESCRIPTION
This PR looks to unpack the data into the expected file structure, then apply the patch files over the top - adding any new files that may have been added outside of this step. This should also aid in handling #12 as the extracted data can be stored in a folder passed in the `--gamedatadir` (`-g`) folder. This is also the same for the XAPK unpack directory (as there is an APK that is hosted by the publisher as well, that could be extracted to this folder).

If these are passed in, the user will be asked if they would like them cleared before continuing, although this is not required for processing.

To aid in processing, the steps to loop over nxs and sd files has been combined, as they are being walked over anyway.