### PR TITLE
Major dependency/build fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+# Never modify line endings of our bash scripts
+*.sh -crlf
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.css           text
+*.html          text
+*.java          text
+*.js            text
+*.json          text
+*.properties    text
+*.txt           text
+*.xml           text
+
+# These files are binary and should be left untouched
+# (binary is macro for -text -diff)
+*.class         binary
+*.jar           binary
+*.gif           binary
+*.jpg           binary
+*.png           binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,19 @@
+# IDE files
 /target
-/staticdata
-/xapk
 .ccls-cache
-/data_dump/
 .DS_Store
 .idea/
+
+# Data files
+/staticdata
+/xapk
+/data_dump/
+*.xapk
+
+# Python venv files
+lib
+lib64
+include/
+bin/
+pyvenv.cfg
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .ccls-cache
 /data_dump/
 .DS_Store
+.idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "neox-tools"]
 	path = neox-tools
 	url = https://github.com/xforce/neox-tools.git
+[submodule "unnbk"]
+	path = neox-tools/scripts/unnbk
+	url = https://github.com/YJBeetle/unnpk.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "neox-tools"]
 	path = neox-tools
 	url = https://github.com/xforce/neox-tools.git
-[submodule "unnbk"]
-	path = neox-tools/scripts/unnbk
-	url = https://github.com/YJBeetle/unnpk.git

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,181 @@
+# Manual Installation
+This guide will cover how to install the script including the python decompiler. This guide is made for `Ubuntu` (
+other Linux distributions will probably work similar). If you are running Windows, I recommend to install [WSL](https://learn.microsoft.com/de-de/windows/wsl/install)
+as this will make it a lot easier.
+
+This instruction was written and tested on `Ubuntu 22.04` on Windows 10 WSL with `Python 3.10.12`.
+
+
+
+Table of contents:
+<!-- TOC -->
+* [Manual Installation](#manual-installation)
+    * [Step 0: Install dependencies](#step-0-install-dependencies)
+    * [Step 1: Install repos](#step-1-install-repos)
+    * [Step 2: Build unnpk](#step-2-build-unnpk)
+    * [Step 3: Run it](#step-3-run-it)
+      * [XDIS error](#xdis-error)
+  * [Installing forks](#installing-forks)
+* [Dependency Versions](#dependency-versions)
+  * [APT Packages](#apt-packages)
+  * [Python Packages](#python-packages)
+<!-- TOC -->
+
+
+### Step 0: Install dependencies
+To compile unnpk, you have to install the following dependencies:
+```shell
+sudo apt install -y build-essential libmagic-dev zlib1g-dev
+```
+
+You will also need python. This repo was tested with `Python 3.10.12`. You can install it with
+```shell
+sudo add-apt-repository ppa:deadsnakes/ppa
+# Press [Enter] to confirm it
+
+# Then install python3.10
+sudo apt install -y python3.10 python3.10-venv
+```
+Other versions will probably also work.
+
+
+### Step 1: Install repos
+Those three repositories have to be installed:
+- [eve-echoes-tools](https://github.com/xforce/eve-echoes-tools)
+- [neox-tools](https://github.com/xforce/neox-tools)
+- [unnpk](https://github.com/YJBeetle/unnpk)
+
+If you want to install some from another source, replace the link with your repo link and read the [Installing forks](#installing-forks)
+section for instructions on how to install them.
+
+Clone the repository using the following command
+```shell
+# Clone the main repo, will install it into a folder called eve-echoes-tools
+# Replace the link if you want to clone a fork instead
+git clone https://github.com/xforce/eve-echoes-tools
+
+# Set up python environment, you might need to change the 'python3' command depending on you installation
+python3 -m venv eve-echoes-tools
+
+# Enter the folder
+cd eve-echoes-tools
+
+# Initialize (download) the submodules, if you want to install the other repos manually (because you want
+# to install it from a fork, ignore it and look into the section for installing forks
+git submodule update --init --recursive
+
+# Activate the python venv
+source bin/activate
+
+# Install required python packages to you python environment (make sure that you did activate it)
+pip install -r requirements.txt
+```
+
+### Step 2: Build [unnpk](https://github.com/YJBeetle/unnpk)
+```shell
+# Deactivate the python environment for now
+deactivate
+
+# Install the dev dependencies for unnpk
+sudo apt install -y build-essential libmagic-dev zlib1g-dev
+
+# Enter the neox-toolx/scripts folder
+cd neox-tools/scripts/unnpk
+
+# Build the repository
+# You will get an warning but that can be ignored
+make
+
+# Go back to the root directory (eve-echoes-tools)
+cd ../../..
+```
+
+### Step 3: Run it
+```shell
+# If not already happened, activate it again
+source bin/activate
+
+# Extract data to the staticdata directory
+python scripts/dump_static_data.py staticdata --xapk eve.xapk -g staticdata/gamedata
+```
+After you have run and unpacked
+
+> Note: When decompiling python files, there will be a lot of spam in the console because of failing files.
+> You can just ignore it.
+
+> If you also want to use the raw unpacked data, you can add `-u staticdata/unpack` to the command, this will also save
+> the unpacked data from the apk which can be processed further.
+
+#### XDIS error
+The program might crash with an error similar to this one (you will maybe have another file path and version number):
+```
+ERROR: Please insert version 3.8.18 into /**/**/eve-echoes-tools/lib/python3.8/site-packages/xdis/magics.py
+```
+In this case you have to open the specified file and locate the line with the matching major and minor python version
+(should be around line 300) starting with the function `add_canonic_versions`.
+The major and minor version are the first two numbers. So for example if we have the version `3.8.18` we have to find
+the line that contains similar versions, e.g. `3.8`, `3.8.5`. In our case, the correct line looks like this:
+```python
+add_canonic_versions(
+    "3.8b4 3.8.0candidate1 3.8 3.8.0 3.8.1 3.8.2 3.8.3 3.8.4 3.8.5 3.8.6 3.8.7 3.8.8 3.8.9 3.8.10 3.8.11 3.8.12",
+    "3.8.0rc1+",
+)
+```
+Depending on your version, this might also be multiple lines. To fix the error, you have to insert your python version
+into the first string (separated with a space), in this case it should look like this:
+```python
+add_canonic_versions(
+    # Edit this first string
+    "3.8b4 3.8.0candidate1 3.8 3.8.0 3.8.1 3.8.2 3.8.3 3.8.4 3.8.5 3.8.6 3.8.7 3.8.8 3.8.9 3.8.10 3.8.11 3.8.12 3.8.18",
+    # Don't touch this second string
+    "3.8.0rc1+",
+)
+```
+After that, the error should be gone.
+
+
+## Installing forks
+If you want to install the repos from another source, you have to skip the `git submodule` command and install
+them manually:
+```shell
+# Inside the eve-echoes-tools folder
+
+# Install neox-tools
+# Replace the link with the fork link (or leave it)
+git clone https://github.com/xforce/neox-tools
+
+cd neox-tools/scripts
+
+# Install unnpk
+# Replace the link with the fork link (or leave it)
+git clone https://github.com/YJBeetle/unnpk
+
+# Go back into the eve-echoes-tools directory and continue the installation instruction
+cd ../..
+```
+
+# Dependency Versions
+This repo is not actively maintained, in case you want to make use of it in the future, you can find the latest tested
+dependency versions here. If the latest versions do not work because they introduced breaking changes, you can revert to
+these versions instead.
+## APT Packages
+
+| package         | version                  |
+|-----------------|--------------------------|
+| python3.10      | 3.10.12-1~22.04.2        |
+| build-essential | 12.9ubuntu3              |
+| libmagic-dev    | 1:5.41-3ubuntu0.1        |
+| zlib1g-dev      | 1:1.2.11.dsfg-2ubuntu9.2 |
+
+## Python Packages
+You can find these packages in the file `requirements-lock.txt`
+
+| package      | version |
+|--------------|---------|
+| uncompyle6   | 3.9.0   |
+| xdis         | 6.0.5   |
+| mmh3         | 4.0.1   |
+| spark-parser | 1.8.9   |
+| parso        | 0.8.3   |
+| click        | 8.1.7   |
+| six          | 1.16.0  |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cd eve-echoes-tools
 
 # Initialize (download) the submodules, if you want to install the other repos manually (because you want
 # to install it from a fork, ignore it and look into the section for installing forks
+# The section can be found in the INSTALLATION.md file
 git submodule update --init --recursive
 
 # Enter the neox-toolx/scripts folder

--- a/README.md
+++ b/README.md
@@ -8,11 +8,21 @@ Eve Echoes Tools
 
 A collection of tools to convert, extract and modify the game files of Eve Echoes.
 
-<br>
 
-## Installation
+This project is only partially maintained and has experienced some breaking changes in the dependencies. You can find
+a list of the latest tested and working dependency version at the end of [INSTALLATION.md](INSTALLATION.md). There is
+also a `requirements-lock.txt` file that contains the exact package versions.
 
-Only a few tools in this repo can be installed on your machine, this is generally intended to be run in a clone.</br>
+The Docker installation is currently broken, if you still want to use docker, you have to fix it.
+
+## Docker Installation
+
+The detailed instructions for a manual installations can be found in .
+
+> The docker script is currently broken because the installation requires some hacky solutions. Please install it
+> manually
+
+~~Only a few tools in this repo can be installed on your machine, this is generally intended to be run in a clone.~~</br>
 The primary use-case of this for now is to dump all the static data of Eve Echoes into JSON files.
 
 The easiest way this can be done is by using the docker image which has all the required tools installed.</br>
@@ -47,10 +57,12 @@ Simple tools to interact with the engine files of NeoX as used in Eve Echoes and
 
 ## Installing
 
-All you have to do to build it is clone it an run on of the following:
+> This section does probably also no longer work, please refer to the manual installation page.
+
+All you have to do to build it is clone it and run on of the following:
 
 ```
-cargo install --path <path to tool>
+cargo install --path {path to tool}
 ```
 
-> <Path to tool> to be replaced by one of the directories in this repo.
+> {path to tool} to be replaced by one of the directories in this repo.

--- a/README.md
+++ b/README.md
@@ -17,26 +17,58 @@ The Docker installation is currently broken, if you still want to use docker, yo
 
 ## Docker Installation
 
-The detailed instructions for a manual installations can be found in .
+The detailed instructions for a manual installations can be found in [INSTALLATION.md](INSTALLATION.md).
 
-> The docker script is currently broken because the installation requires some hacky solutions. Please install it
-> manually
-
-~~Only a few tools in this repo can be installed on your machine, this is generally intended to be run in a clone.~~</br>
+Only a few tools in this repo can be installed on your machine. ~~this is generally intended to be run in a clone.~~</br>
 The primary use-case of this for now is to dump all the static data of Eve Echoes into JSON files.
 
 The easiest way this can be done is by using the docker image which has all the required tools installed.</br>
 Simply run. (With the latest Eve Echoes XAPK in the local directory named `eve.xapk`)
+
+If not already happened, clone the repos
+```shell
+# Replace the url if you want to clone a fork instead
+# This command will create a folder eve-echoes-tools
+git clone https://github.com/xforce/eve-echoes-tools
+
+# Enter the folder
+cd eve-echoes-tools
+
+# Initialize (download) the submodules, if you want to install the other repos manually (because you want
+# to install it from a fork, ignore it and look into the section for installing forks
+git submodule update --init --recursive
+
+# Enter the neox-toolx/scripts folder
+cd neox-tools/scripts
+
+# Clone unnpk
+git clone https://github.com/YJBeetle/unnpk.git
+
+# Go back into the root directory (eve-echoes-tools)
+cd ../...
+```
+
+> **IMPORTANT**: Make sure that the file `docker/cmd.sh` has Linux line endings (LF) and not Windows line endings (CRLF)
+> If you get the error `exec /opt/cmd.sh: no such file or directory` when running the container, you have to fix the line
+> endings and re-build the container.
+
+After all repos are downloaded, build the container with this command
+```shell
+# Inside the eve-echoes-tools directory run
+docker build -f docker/Dockerfile -t cookiemagic/evee-tools .
+# The dot at the end is crucial!
+```
+
+Once the build is completed, run it with this command. Make sure that the xapk in inside the `eve-echoes-tools` directory.
+This command will extract all data into the staticdata directory. It will only save the final output, if you want to
+use all raw data (to e.g. extract images and other assets), please refer to the manual installation page. The container
+will only save the json and script data.
 
 ```
 docker run -v$(pwd):/data cookiemagic/evee-tools dump_static /data/eve.xapk /data/staticdata
 ```
 
 > On windows adjust the Mount accordingly.
-> You can build the docker image on windows using PowerShell (in the root directory) with
-> ```
-> docker build -f docker/Dockerfile -t cookiemagic/evee-tools .
-> ```
 > To run it, you have to put the `$(pwd):/data` part in quotes when using PowerShell:
 > ```
 > docker run -v "$(pwd):/data" cookiemagic/evee-tools dump_static /data/eve.xapk /data/staticdata
@@ -57,7 +89,7 @@ Simple tools to interact with the engine files of NeoX as used in Eve Echoes and
 
 ## Installing
 
-> This section does probably also no longer work, please refer to the manual installation page.
+> This section does probably also only partially work
 
 All you have to do to build it is clone it and run on of the following:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,11 @@
+# Migh want to replace this also with python:3.10-alpine, but we don't really need python here
+# and for the moment two different images don't seem to cause any problems.
 FROM alpine:edge as cargo-build
 
+# Dependencies for neox-tools/fsd2json
 RUN apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing rust cargo
+# Dependencies for unnpk
+RUN apk add --no-cache libmagic file file-dev zlib-dev make
 
 WORKDIR /app
 ADD Cargo.toml Cargo.toml
@@ -11,21 +16,39 @@ ADD fsd2json/Cargo.toml /app/fsd2json/Cargo.toml
 ADD neox-tools/src /app/neox-tools/src
 ADD neox-tools/Cargo.toml /app/neox-tools/Cargo.toml
 
+ADD neox-tools/scripts/unnpk /app/unnpk/src
+
+# Building unnpk
+WORKDIR /app/unnpk/src/
+RUN make
+
+# Build neox-tools/fsd2json
+WORKDIR /app
 RUN cargo install --path fsd2json --root /usr/local/
 RUN cargo install --path neox-tools --root /usr/local/
 
-FROM alpine:edge
+
+
+FROM python:3.10-alpine
+# We need python3.10, xdis does not support python 3.11 at the moment
 
 COPY --from=cargo-build /usr/local/bin/fsd2json /usr/local/bin/fsd2json
 COPY --from=cargo-build /usr/local/bin/npktool /usr/local/bin/npktool
+COPY --from=cargo-build /app/unnpk/src /opt/eve-echoes-tools/neox-tools/scripts/unnpk
 
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing git python3 py3-pip py3-mmh3 bash
-RUN pip install --break-system-packages --no-cache-dir mmh3 xdis spark-parser parso
 
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing libgcc
+
 ADD https://api.github.com/repos/xforce/eve-echoes-tools/compare/main...HEAD /dev/null
 WORKDIR /opt/eve-echoes-tools
 COPY . /opt/eve-echoes-tools
+
+RUN pip install --break-system-packages --no-cache-dir -r requirements.txt
+
+# Apply xdis patch
+# This is a very hacky solution, it will edit the library file of xdis
+RUN python scripts/docker_fix_xdis.py
 
 COPY docker/cmd.sh /opt/
 ENTRYPOINT ["/opt/cmd.sh"]

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,0 +1,8 @@
+uncompyle6==3.9.0
+xdis==6.0.5
+mmh3==4.0.1
+spark-parser==1.8.9
+parso==0.8.3
+## The following requirements were added by pip freeze:
+click==8.1.7
+six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-xdis==6.0.1 # Any older version will NOT work
+uncompyle6~=3.9.0
+xdis
 mmh3
 spark-parser
 parso

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+xdis==6.0.1 # Any older version will NOT work
+mmh3
+spark-parser
+parso

--- a/scripts/docker_fix_xdis.py
+++ b/scripts/docker_fix_xdis.py
@@ -1,0 +1,38 @@
+import os.path
+import re
+import sys
+
+# xdis.magics contains a list of hardcoded python version strings. However, this file may not contain our current
+# python version, so we have to check it and add it if necessary. The magics.py file contains a long list of function
+# calls similar to this one:
+#   add_canonic_versions(
+#       "3.10 3.10.0 3.10.1 3.10.2 3.10.3 3.10.4 3.10.5 3.10.6 3.10.7 3.10.8 3.10.9", "3.10.0rc2"
+#   )
+# These map the python versions (in this case a selection of 3.10.x versions) onto a base version (in this case 3.10.0rc2)
+# We will add our own line that registers our version. Currently only python 3.10.x is supported by this script.
+if __name__ == "__main__":
+    print("Checking xdis")
+    from xdis import magics
+    from xdis.op_imports import version_tuple_to_str
+
+    ver_str = version_tuple_to_str(sys.version_info)
+    if ver_str in magics.canonic_python_version:
+        # xdis knows our python version
+        print(f"XDIS knows our version ({ver_str}) already")
+        exit(0)
+    # Check if we are running python 3.10.xx
+    if not re.match(r"3\.10\.\d+", ver_str):
+        # Unsupported python version, can't apply auto-patch
+        print(f"Unsupported python version {ver_str}, only python3.10.xx is supported")
+        exit(135)
+    # Python 3.10 detected, applying patch
+    file_path = magics.__file__
+    if not os.path.exists(file_path):
+        print("Error: File not found: " + file_path)
+        exit(136)
+    # Open xdis/magics.py file in append mode and add our version to the end
+    with open(file_path, "a") as file:
+        file.write(f"\nadd_canonic_versions('{ver_str}', '3.10.0rc2')\n")
+        print(f"Info: Applied patch, inserted {ver_str} into {file_path}")
+        exit(0)
+

--- a/scripts/dump_static_data.py
+++ b/scripts/dump_static_data.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import logging
-from typing import Dict
+from typing import Dict, Tuple, List
 
 import mmh3
 import argparse
@@ -21,7 +20,25 @@ import collections
 from multiprocessing import Pool, Lock
 
 PYTHON3 = sys.version_info >= (3, 0)
-PATCH_FILE_INDEX="2081783950193513057"
+PATCH_FILE_INDEX = "2081783950193513057"
+NO_SCRIPT = False
+
+
+def check_xdis():
+    # xdis has a hardcoded list with all existing python versions. However, this list is not up-to-date and there are
+    # missing versions. Going further, we can't use the latest version of xdis because it has breaking changes.
+    # Because the decompilation happens in separate threads, the user will have to fix this manually
+    from xdis import magics
+    from xdis.op_imports import version_tuple_to_str
+    ver_str = version_tuple_to_str(sys.version_info)
+    print("Detected python version " + ver_str)
+    if ver_str in magics.canonic_python_version:
+        return  # xdis knows our version, nothing to do for us
+    warn(f"xdis does not know our python version, it has to be inserted manually into {magics.__file__}")
+    warn(f"Please insert our version {ver_str} into the correct \"add_canonic_versions\" command")
+    warn("You can just select the one with the same major and minor version number")
+    warn("For example if we have the version 3.8.18, insert this number into the line with the other 3.8.x versions")
+    error(f"Please insert version {ver_str} into {magics.__file__}")
 
 
 class SetEncoder(json.JSONEncoder):
@@ -31,13 +48,13 @@ class SetEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def error(msg):
+def error(msg: str):
     prefix = '\033[1m\033[31mERROR\033[0m' if os.isatty(1) else 'ERROR'
     print('%s: %s' % (prefix, msg))
     sys.exit(1)
 
 
-def warn(msg):
+def warn(msg: str):
     warn.warned = True
     prefix = '\033[1m\033[93mWARNING\033[0m' if os.isatty(1) else 'WARNING'
     print('%s: %s' % (prefix, msg))
@@ -78,28 +95,35 @@ parser.add_argument('-g', '--gamedatadir', type=str, action='store',
 parser.add_argument('-p', '--patch', type=str, action='store',
                     help="Patch directory to use")
 
-parser.add_argument('--patch_game_files', action='store_true',
+parser.add_argument('-patch', '--patch_game_files', action='store_true',
                     help="Only patch saved game files, skip unpacking")
-                    
+
+parser.add_argument('-s', '--skip_delete', action='store_true',
+                    help="Don't ask if the unpack and gamedata dir should get deleted (those directory wont be deleted)")
+
+parser.add_argument('--no_script', action='store_true',
+                    help="Will not try to extract .nxs files and only process .sd files.")
 
 args = parser.parse_args()
 
-def yes_or_no(question):
-    reply = str(input(question+' (y/n): ')).lower().strip()
+
+def yes_or_no(question: str):
+    reply = str(input(question + ' (y/n): ')).lower().strip()
     if reply[0] == 'y':
         return True
     if reply[0] == 'n':
         return False
     else:
         return yes_or_no("Uhhhh... please enter ")
-@contextlib.contextmanager
-def tempdir_if_required(dirpath):
 
+
+@contextlib.contextmanager
+def tempdir_if_required(dirpath, skip_clear_question=False):
     if dirpath is None:
         cleanup_needed = True
-        dirpath = tempfile.mkdtemp() 
+        dirpath = tempfile.mkdtemp()
     else:
-        if os.path.exists(dirpath) and yes_or_no('Clear folder?: {}'.format(dirpath)):
+        if os.path.exists(dirpath) and not skip_clear_question and yes_or_no('Clear folder?: {}'.format(dirpath)):
             shutil.rmtree(dirpath)
 
         os.makedirs(dirpath, exist_ok=True)
@@ -108,6 +132,7 @@ def tempdir_if_required(dirpath):
     def cleanup(cleanup_needed):
         if cleanup_needed:
             shutil.rmtree(dirpath)
+
     try:
         yield dirpath
     except Exception as e:
@@ -122,6 +147,7 @@ def tempdir():
 
     def cleanup():
         shutil.rmtree(dirpath)
+
     try:
         yield dirpath
     except Exception as e:
@@ -148,12 +174,14 @@ def execute_stdout(argv, no_output=False, env=os.environ):
             print(e.output)
         raise e
 
+
 ####
 # Patch file management
 ####
 
 patch_file_map = collections.OrderedDict()
 patch_file_list = None
+
 
 def process_patch_file_listing(patch_file_dir):
     with open(os.path.join(patch_file_dir, "0", "1", PATCH_FILE_INDEX), "rb") as f:
@@ -162,7 +190,7 @@ def process_patch_file_listing(patch_file_dir):
     if type(filelist) is not str:
         filelist = filelist.decode('utf-8')
 
-    global patch_file_list 
+    global patch_file_list
     patch_file_list = os.path.join(patch_file_dir, "filelist.txt")
     with open(patch_file_list, "w") as f:
         f.write(filelist)
@@ -200,11 +228,12 @@ def apply_patch_files(patch_file_dir, game_data_dir):
 
                 if not os.path.exists(patch_file_path_dest_dir):
                     os.makedirs(patch_file_path_dest_dir, exist_ok=True)
-                
+
                 shutil.copyfile(patch_file_path_src, patch_file_path_dest)
             else:
                 warn('Patch file not found in index! {}'.format(filename))
     print('\033[KPatch files applied.')
+
 
 # TODO(alexander): Move this to neox-tools
 # In some way at least, maybe strip it down a bit idk
@@ -213,15 +242,16 @@ def init(l):
     global lock
     lock = l
 
+
 ####
 # Process Game Data
 ####
 
-def search_for_scripts(game_data_dir):
+def search_for_scripts(game_data_dir: str):
     # Prepare data for parallel execution
-    files = []
+    files = []  # type: List[Tuple[str, str, str]]
     for root, dirnames, filenames in os.walk(game_data_dir):
-        for filename in filenames:            
+        for filename in filenames:
             dir = os.path.relpath(root, game_data_dir)
             files.append((filename, dir, root))
 
@@ -237,26 +267,33 @@ def search_for_scripts(game_data_dir):
     pool = Pool(int(multiprocessing.cpu_count()),
                 initializer=init, initargs=(lock,))
 
-    if len(files) > 0:
+    if len(files) == 0:
+        warn("No files found")
+        return
+    if not NO_SCRIPT:
         # Make sure we even have a compatible decrypt plugin available
         # If we don't, just abort and tell the user such, nothing else we can do.
-        file = files[0]
-        init(lock,)
+        file = next(filter(lambda file_tuple: file_tuple[0].endswith(".nxs"), files), None)
+
+        init(lock, )
         if not parse_file_unpack(file):
-            warn(
-                "Script redirect decrypt plugin not found, disable script decompilation and script data extraction")
+            warn("Script redirect decrypt plugin not found, aborted script decompilation and script data extraction")
             return
 
-        files = files[1:]
-        pool.map_async(parse_file_unpack, files).get(9999999)
+    files = files[1:]
+    pool.map_async(parse_file_unpack, files).get(9999999)
+
 
 def parse_file(filename, relative_dir, root_dir):
     if filename.endswith(".nxs"):
+        if NO_SCRIPT:
+            return True
         return dump_script(filename, relative_dir, root_dir)
     elif filename.endswith('.sd'):
         return dump_sd(filename, relative_dir, root_dir)
     else:
         return True
+
 
 def dump_sd(filename, relative_dir, root_dir):
     file_path = os.path.join(root_dir, filename)
@@ -267,16 +304,17 @@ def dump_sd(filename, relative_dir, root_dir):
         execute(["fsd2json", "-o", sd_json_dir, file_path])
     else:
         execute(["cargo", "run", "--bin",
-                    "fsd2json", "--", "-o", sd_json_dir, file_path])
+                 "fsd2json", "--", "-o", sd_json_dir, file_path])
 
     return True
+
 
 def dump_script(filename, relative_dir, root_dir):
     try:
         file_path = os.path.join(root_dir, filename)
 
         script_redirect_out = execute_stdout(
-            [sys.executable, "neox-tools/scripts/script_redirect.py", file_path], True)
+            [sys.executable, "neox-tools/scripts/script_redirect.py", file_path], False)
     except subprocess.CalledProcessError as e:
         if e.returncode >= 132:
             return False
@@ -348,6 +386,7 @@ def dump_script(filename, relative_dir, root_dir):
 def parse_file_unpack(args):
     return parse_file(*args)
 
+
 ####
 # Unpack Game Data
 ####
@@ -374,6 +413,7 @@ def dump_from_unpacked_data(unpacked_dir, output_dir):
 
     execute_cmds.extend(npk_files)
     execute(execute_cmds)
+
 
 ####
 # Transform Python Data
@@ -412,9 +452,9 @@ def cleanup_dict(data: Dict):
     for k, v in data.items():
         if type(v) is bytes:
             data[k] = v.decode("utf-8")
-            logging.warning("Decoded value bytes %s to utf-8", v)
+            print("Decoded value bytes %s to utf-8", v)
         if type(k) is bytes:
-            logging.warning("Decoded key bytes %s to utf-8", k)
+            print("Decoded key bytes %s to utf-8", k)
             to_add[k.decode("utf-8")] = data[k]
             to_delete.append(k)
         if type(v) is dict:
@@ -516,6 +556,7 @@ def extract_data_from_python(filename, directory, sub):
                 if not PYTHON3:
                     j = json.dumps(
                         out_data, ensure_ascii=False, indent=4, encoding='utf8')
+                    # ToDo: is this correct? Showing 'unresolved reference' for me and don't find an import
                     f.write(unicode(j))
                 else:
                     j = json.dumps(
@@ -545,73 +586,88 @@ def convert_files(root_dir, sub):
     import multiprocessing
     pool = Pool(int(multiprocessing.cpu_count()),
                 initializer=init, initargs=(lock,))
-    init(lock,)
+    init(lock, )
     pool.map_async(extract_data_from_python_unpack, files).get(9999999)
+
 
 ####
 # Main
 ####
 
 if __name__ == '__main__':
-
     if args.unpackdir is None and args.xapk is None and args.patch_game_files is not True:
         print('You must give either an unpacked data directory, or an (X)APK containing all the assets.')
+        exit(1)
+
+    if args.no_script or NO_SCRIPT:
+        warn("Script extraction is disabled, won't process .nxs files")
+        NO_SCRIPT = True
     else:
-        with tempdir_if_required(args.gamedatadir) as game_data_dir:
-            with tempdir_if_required(args.unpackdir) as unpack_dir:
-                print('----------------------------')
-                print('Unpack Data:', unpack_dir)
-                print('Game Data:', game_data_dir)
-                print('Output Folder:', args.outdir)
-                print('----------------------------')
+        check_xdis()
 
-                ## Parse Patch file listing (if it exists)
-                if args.patch is not None:
-                    process_patch_file_listing(args.patch)
+    with tempdir_if_required(args.gamedatadir, args.skip_delete) as game_data_dir:
+        with tempdir_if_required(args.unpackdir, args.skip_delete) as unpack_dir:
+            print('----------------------------')
+            print('Unpack Data:', unpack_dir)
+            print('Game Data:', game_data_dir)
+            print('Output Folder:', args.outdir)
+            print('----------------------------')
 
-                ## Unpack XAPK if required
-                if args.xapk is not None:
-                    with tempdir() as xapk_temp_dir:
-                        print('Unpacking XAPK:', xapk_temp_dir)
-                        with zipfile.ZipFile(args.xapk, 'r') as zip_ref:
-                            zip_ref.extractall(xapk_temp_dir)
-                            # Walk the files
-                            for root, dirnames, filenames in os.walk(xapk_temp_dir):
-                                for filename in filenames:
-                                    file_path = os.path.join(root, filename)
-                                    ## Unpack APK to (temp directory)
-                                    if filename.endswith(".apk"):
-                                        print('Unpacking APK files')
-                                        with zipfile.ZipFile(file_path) as apk_zip:
-                                            apk_zip.extractall(unpack_dir)
-                                    ## Unpack OBB to (temp directory)\assets
-                                    ## Depending on APK - this might already be in place
-                                    elif filename.endswith(".obb"):
-                                        print('Unpacking OBB files')
-                                        obb_unpack = os.path.join(unpack_dir, 'assets')
-                                        with zipfile.ZipFile(file_path) as obb_zip:
-                                            obb_zip.extractall(obb_unpack)
+            ## Parse Patch file listing (if it exists)
+            if args.patch is not None:
+                process_patch_file_listing(args.patch)
 
-                ## Extract all NPK files to game_data folder
-                if args.patch_game_files is not True:
-                    print('Extracting game assets')
-                    dump_from_unpacked_data(unpack_dir, game_data_dir) 
-                    ## Copy OBB res/* to game_data folder
-                    print('Moving static data into game data...')
-                    static_data_src = os.path.join(unpack_dir, 'assets', 'res', 'staticdata')
-                    static_data_dest = os.path.join(game_data_dir, 'staticdata')
+            ## Unpack XAPK if required
+            if args.xapk is not None:
+                if not os.path.exists(args.xapk):
+                    error(f"Path to XAPK not found: {args.xapk}")
+                    exit(1)
+                with tempdir() as xapk_temp_dir:
+                    print('Unpacking XAPK:', xapk_temp_dir)
+                    with zipfile.ZipFile(args.xapk, 'r') as zip_ref:
+                        zip_ref.extractall(xapk_temp_dir)
+                        # Walk the files
+                        for root, dirnames, filenames in os.walk(xapk_temp_dir):
+                            for filename in filenames:
+                                file_path = os.path.join(root, filename)
+                                ## Unpack APK to (temp directory)
+                                if filename.endswith(".apk"):
+                                    print('Unpacking APK files')
+                                    with zipfile.ZipFile(file_path) as apk_zip:
+                                        apk_zip.extractall(unpack_dir)
+                                ## Unpack OBB to (temp directory)\assets
+                                ## Depending on APK - this might already be in place
+                                elif filename.endswith(".obb"):
+                                    print('Unpacking OBB files')
+                                    obb_unpack = os.path.join(unpack_dir, 'assets')
+                                    with zipfile.ZipFile(file_path) as obb_zip:
+                                        obb_zip.extractall(obb_unpack)
+
+            ## Extract all NPK files to game_data folder
+            if args.patch_game_files is not True:
+                print('Extracting game assets')
+                dump_from_unpacked_data(unpack_dir, game_data_dir)
+                ## Copy OBB res/* to game_data folder
+                print('Moving static data into game data...')
+                static_folders = ["staticdata", "sigmadata", "manual_staticdata"]
+                for folder in static_folders:
+                    static_data_src = os.path.join(unpack_dir, 'assets', 'res', folder)
+                    static_data_dest = os.path.join(game_data_dir, folder)
+                    print(f"Coping from {static_data_src} to {static_data_dest}")
                     shutil.copytree(static_data_src, static_data_dest, dirs_exist_ok=True)
-            
-                ## Copy patchfiles into game_data and rename            
-                if args.patch is not None:
-                    apply_patch_files(args.patch, game_data_dir)
 
-                ## Process all files in output 
-                print('Searching scripts...')
-                search_for_scripts(game_data_dir)
+            ## Copy patchfiles into game_data and rename
+            if args.patch is not None:
+                apply_patch_files(args.patch, game_data_dir)
 
-                ## Convert Python data files
-                print('Converting Python data files...')
-                convert_files(os.path.join(args.outdir, "script", "data"), "data")
-                convert_files(os.path.join(args.outdir, "script",
-                                            "data_common"), "data_common")
+            ## Process all files in output
+            if args.no_script or NO_SCRIPT:
+                warn("Script extraction is disabled, won't process .nxs files")
+            print('Searching scripts...')
+            search_for_scripts(game_data_dir)
+
+            ## Convert Python data files
+            print('Converting Python data files...')
+            convert_files(os.path.join(args.outdir, "script", "data"), "data")
+            convert_files(os.path.join(args.outdir, "script",
+                                       "data_common"), "data_common")


### PR DESCRIPTION
The current version of this repo does not properly extract the staticdata, because the script decompilation does not work. The main problems are caused by neox-tools because the script_redirect plugin was missing and some dependencies have introduced breaking changes/are incompatible with Python 3.11.

The first dependency that was, as far as I can tell, missing, is [unnpk](https://github.com/YJBeetle/unnpk). I am not sure why it is missing, especially because unnpk contains .py files with the same names as neox-tools. So I am not sure if unnpk is really required, but the `script_redirect.py` file is trying to load it without sucess.

Going further, it seems like that the `uncompyle6` submodule is not working properly. I don't know exactly why, but I have replaced it with the `pip` package which seems to be working normaly. This requires an update of neox-tools (refer to the [pull request](https://github.com/xforce/neox-tools/pull/19)).

The next problem was `xdis`, a dependency of `uncompyle6`. It does not support Python 3.11, so I have adjusted the installation instructions for Python 3.10. Also `xdis` has an hardcoded list of available Python versions, but the latest version are missing. I have added an check and hotfix script that is able to insert the installed Python version into `xdis`. This does only work for Python 3.10.xx, older versions have to be inserted manually (there are instructions available). *This is a very hacky solution, because the script edits the packaged directly*. But because the decompilation is a separate process, it is the only solution (adding the version during runtime does not work).

Because I know that neox-tools is also used for other games, I tried to fix everything in this repo so I don't introduce any breaking changes to [neox-tools](https://github.com/xforce/neox-tools). Only some slight modifications were required to ensure the `pip` version of uncompyle6 gets used if available.
**_This pull request does not work until the pull request in neox-tools gets approved_**: https://github.com/xforce/neox-tools/pull/19

I also have updated the `Dockerfile` to fix these problems. This include the change from `alpine:edge` to `python:3.10-alpine` because the latest version of alpine only has Python 3.11 available. I also added unnpk to the `cargo-build` section, so it gets build and copied into the final image. This does also include some new dependencies that are required to build unnpk.

I have added detailed installation instructions, both for the manual installation, as well as for the docker build. This does also include a list of the specific packaged and dependency versions. Should some packages introduce breaking changes in the future, these lists can be used to build a functional version of eve-echoes-tools.